### PR TITLE
fix build command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## Development
 
 ```bash
-npm i && npm build
+npm i && npm run build
 ```
 
 ## Meta


### PR DESCRIPTION
I suspect `npm build` should be `npm run build`.